### PR TITLE
Powerline - ensure transparency when needed

### DIFF
--- a/theme/powerline.elv
+++ b/theme/powerline.elv
@@ -91,6 +91,7 @@ segment-style-fg = [
 ]
 
 segment-style-bg = [
+	&default= "0"
 	&arrow= (+ (% $pid 216) 16)
 	&su= "161"
 	&dir= "31"
@@ -311,7 +312,7 @@ fn -prompt-builder {
 					if (not (eq $seg "newline")) {
 						-colorprint $glyph[chain] $lbg $last-bg
 					} else {
-						-colorprint $glyph[chain] $lbg "0"
+						-colorprint $glyph[chain] $lbg $segment-style-bg[default]
 					}
 				}
 				put $@output
@@ -322,7 +323,7 @@ fn -prompt-builder {
 				}
 			}
 		}
-		-colorprint $glyph[chain]" " $last-bg "0"
+		-colorprint $glyph[chain]" " $last-bg $segment-style-bg[default]
 	}
 
 	put $-build-chain~

--- a/theme/powerline.elv
+++ b/theme/powerline.elv
@@ -141,10 +141,16 @@ fn session-color-picker {
 ######################################################################
 fn -prompt-builder {
 	# last-bg is the background color of the last printed segment
-	last-bg = 0
+	last-bg = $segment-style-bg[default]
 
 	fn -colorprint [what fg bg]{
-		fn st [seg]{ styled-segment $seg &fg-color="color"$fg &bg-color="color"$bg }
+		fn st [seg]{
+			if (eq $bg "transparent") {
+				styled-segment $seg &fg-color="color"$fg
+			} else {
+				styled-segment $seg &fg-color="color"$fg &bg-color="color"$bg
+			}
+		}
 		styled $what $st~
 		last-bg = $bg
 	}

--- a/theme/powerline.elv
+++ b/theme/powerline.elv
@@ -91,7 +91,7 @@ segment-style-fg = [
 ]
 
 segment-style-bg = [
-	&default= "0"
+	&default= "transparent"
 	&arrow= (+ (% $pid 216) 16)
 	&su= "161"
 	&dir= "31"


### PR DESCRIPTION
For some reason, I'm unable to find the exact color of my backtround when configuring my powerline prompt. With the change I propose in here, instead of finding it out, the value "transparent" basically doesn't set the background and let's elvish figure it out.

I've been using it for a while myself and it works