### PR TITLE
Remove deprecation errors for Elvish v0.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Libs & Themes for [elvish](https://github.com/elves/elvish)
 
 ## Install
 
-Make sure you run elvish 0.11 or newer. Install this module by running the
+Make sure you run elvish 0.20 or newer. Install this module by running the
 following commands in your shell:
 
 ```

--- a/git.elv
+++ b/git.elv
@@ -53,7 +53,7 @@ fn status {|&counts=$false|
   var rev-behind      = 0
   var is-git-repo     = $false
 
-  var is-ok = ?($git-status-cmd | eawk {|line @f|
+  var is-ok = ?($git-status-cmd | re:awk {|line @f|
       # pprint "@f=" $f
       -switch $f[0] [
         &"#"= {


### PR DESCRIPTION
In Elvish v0.20, eawk was deprecated in favour of re:awk. This also means that this Elvish v0.20+ must be used.