### PR TITLE
Use re:awk instead of eawk for 0.20 compatibility

### DIFF
--- a/git.elv
+++ b/git.elv
@@ -53,7 +53,7 @@ fn status {|&counts=$false|
   var rev-behind      = 0
   var is-git-repo     = $false
 
-  var is-ok = ?($git-status-cmd | eawk {|line @f|
+  var is-ok = ?($git-status-cmd | re:awk {|line @f|
       # pprint "@f=" $f
       -switch $f[0] [
         &"#"= {


### PR DESCRIPTION
0.20.0 deprecated `eawk` in favour of `re:awk`. This commit reflects this change.